### PR TITLE
Add autoprefixer to PostCSS config

### DIFF
--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,5 +1,6 @@
 export default {
   plugins: {
     "@tailwindcss/postcss": {},
+    autoprefixer: {},
   }
 }


### PR DESCRIPTION
## Summary
- register autoprefixer in `postcss.config.mjs`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b117803c832182c8d7c8ae5ea66f