### PR TITLE
Add bash reset script

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,19 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Resetting the project
+
+To remove the default Next.js files and start with a clean structure you can run:
+
+```bash
+./Reset-Project.sh
+```
+
+On Windows, use PowerShell:
+
+```powershell
+./Reset-Projeto.ps1
+```
+
+The script cleans the `src/app` files and the `public` directory, then recreates empty `layout.tsx`, `page.tsx` and `src/styles/globals.css`.

--- a/Reset-Project.sh
+++ b/Reset-Project.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Reset-Project.sh
+# Run from the project root to wipe the default Next.js/Tailwind files.
+
+set -e
+
+echo "🧹 Cleaning default Next.js + Tailwind project files..."
+
+# Files to remove from src/app
+files=(
+  "src/app/page.tsx"
+  "src/app/layout.tsx"
+  "src/app/favicon.ico"
+  "src/app/globals.css"
+)
+
+for f in "${files[@]}"; do
+  if [ -e "$f" ]; then
+    rm -f "$f"
+    echo "🗑️ Removed: $f"
+  fi
+done
+
+# Clean the public directory
+public_dir="public"
+if [ -d "$public_dir" ]; then
+  rm -rf "$public_dir"/*
+  echo "🧼 public/ directory cleaned"
+fi
+
+# Recreate minimal structure
+mkdir -p src/app src/styles
+: > src/app/layout.tsx
+: > src/app/page.tsx
+: > src/styles/globals.css
+
+echo -e "\n✅ Project cleaned and ready to start from scratch!"


### PR DESCRIPTION
## Summary
- provide `Reset-Project.sh` bash helper to clean up default Next.js files
- document how to use the cleanup scripts

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6841b11a1e508321a71146f9401358a4