### PR TITLE
Add autoprefixer to PostCSS configuration

### DIFF
--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,5 +1,6 @@
 export default {
   plugins: {
     "@tailwindcss/postcss": {},
+    autoprefixer: {},
   }
 }


### PR DESCRIPTION
## Summary
- include `autoprefixer: {}` in `postcss.config.mjs`
- run `npm install` and `npm run lint`

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841b60a4ca883218ee205c4c820c376